### PR TITLE
Acts as file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pkg/*
 data/*
 log/*
 fluentd-server/*
+spec/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 2.1
 gemfile:
   - Gemfile
+env:
+  - DATA_DIR=spec/tmp
+  - DATA_DIR=

--- a/README.md
+++ b/README.md
@@ -99,16 +99,22 @@ HOST=0.0.0.0
 # LOG_LEVEL=warn
 ```
 
+### DATA_DIR (experimental)
+
+Configure `DATA_DIR` in `.env` file as:
+
+```
+DATA_DIR=data
+```
+
+to use the file storage feature. This will save and load Fluentd config contents not from DB, but from local files located at the directory `DATA_DIR`.
+This would be useful when you want to manage your config files with git. 
+
 ## HTTP API
 
 See [API.md](API.md).
 
 ## ToDo
-
-* Local file storage
-
-  * Saving and loading conf from localfiles rather than DB would be nice because it makes possible to manage conf with git
-  * Fluentd Server should cache them on memory, and refresh caches by detecting files are updated
 
 * Restart Fluentd processes from Fluentd Server
 

--- a/lib/ext/activerecord/acts_as_file.rb
+++ b/lib/ext/activerecord/acts_as_file.rb
@@ -1,0 +1,55 @@
+module ActiveRecord; end
+
+module ActiveRecord::ActsAsFile
+  def self.included(klass)
+    klass.extend(ClassMethods)
+  end
+
+  # ToDo: rename if filename is changed
+  module ClassMethods
+    # acts_as_file :field, :filename => self.instance_method(:filename)
+    def acts_as_file(field, options = {})
+      filename_instance_method = options[:filename]
+      field_name = :"@#{field}" 
+      self.class_eval do
+        unless method_defined?(:save_with_file)
+          define_method(:save_with_file) do
+            filename = filename_instance_method.bind(self).call
+            content  = self.instance_variable_get(field_name)
+            File.open(filename, 'w') do |f|
+              f.flock(File::LOCK_EX) # inter-process locking
+              f.sync = true
+              f.write(content)
+              f.flush
+            end if filename and content
+            save_without_file
+          end
+          alias_method :save_without_file, :save
+          alias_method :save, :save_with_file
+
+          define_method("#{field}=") do |content|
+            self.instance_variable_set(field_name, content)
+          end
+
+          define_method(field) do
+            content = self.instance_variable_get(field_name)
+            return content if content
+            # if (self.updated_at.nil? or File.mtime(filename) > self.updated_at)
+            filename = filename_instance_method.bind(self).call
+            return nil unless filename
+            return nil unless File.exist?(filename)
+            self.instance_variable_set(field_name, File.read(filename))
+          end
+
+          define_method(:destroy_with_file) do
+            filename = filename_instance_method.bind(self).call
+            File.unlink(filename) if File.exist?(filename)
+            destroy_without_file
+          end
+          alias_method :destroy_without_file, :destroy
+          alias_method :destroy, :destroy_with_file
+        end
+      end
+    end
+  end
+end

--- a/lib/fluentd_server/config.rb
+++ b/lib/fluentd_server/config.rb
@@ -5,6 +5,10 @@ require 'dotenv'
 Dotenv.load
 
 module FluentdServer::Config
+  def self.data_dir
+    ENV['DATA_DIR'] == "" ? nil : ENV['DATA_DIR']
+  end
+
   def self.database_url
     ENV.fetch('DATABASE_URL', 'sqlite3:data/fluentd_server.db')
   end

--- a/lib/fluentd_server/model.rb
+++ b/lib/fluentd_server/model.rb
@@ -1,10 +1,23 @@
 require 'sinatra/activerecord'
 require 'sinatra/decorator'
 require 'fluentd_server/environments'
+require 'ext/activerecord/acts_as_file'
 
 class Post < ActiveRecord::Base
   include Sinatra::Decorator::Decoratable
+  include FluentdServer::Logger
 
   validates :name, presence: true
   validates :body, presence: true
+
+  if FluentdServer::Config.data_dir
+    include ActiveRecord::ActsAsFile
+
+    def filename
+      File.join(FluentdServer::Config.data_dir, "#{self.name}.erb") if self.name
+    end
+
+    acts_as_file :body, :filename => self.instance_method(:filename)
+  end
 end
+

--- a/lib/fluentd_server/web.rb
+++ b/lib/fluentd_server/web.rb
@@ -50,14 +50,14 @@ class FluentdServer::Web < Sinatra::Base
   # edit post
   get "/posts/:id/edit" do
     @title = 'Edit'
-    @post = Post.find(params[:id])
-    return 404 unless @post
+    @post = Post.find_by(id: params[:id])
+    redirect "/" unless @post
     slim :"posts/edit"
   end
 
   post "/posts/:id" do
-    @post = Post.find(params[:id])
-    return 404 unless @post
+    @post = Post.find_by(id: params[:id])
+    redirect "/" unless @post
     if @post.update(params[:post])
       redirect "/posts/#{@post.id}/edit", :notice => @post.decorate.success_message
     else

--- a/spec/ext/acts_as_file_spec.rb
+++ b/spec/ext/acts_as_file_spec.rb
@@ -1,0 +1,64 @@
+require_relative '../spec_helper'
+require 'fluentd_server/model'
+require 'ext/activerecord/acts_as_file'
+
+class TestPost < Post
+  unless Post.include?(ActiveRecord::ActsAsFile)
+    include ActiveRecord::ActsAsFile
+    def filename
+      @filename ||= Tempfile.open(self.name) {|f| f.path }.tap {|name| File.unlink(name) }
+    end
+    acts_as_file :body, :filename => self.instance_method(:filename)
+  end
+end
+
+describe 'ActiveRecord::ActsAsFile' do
+  let(:subject) { TestPost.new(name: 'name') }
+  after { TestPost.delete_all }
+  after { File.unlink(subject.filename) if File.exist?(subject.filename) }
+
+  context '#body=' do
+    it { expect { subject.body = 'aaaa' }.not_to raise_error }
+  end
+
+  context '#body' do
+    context 'get from instance variable' do
+      before { subject.body = 'aaaa' }
+      its(:body) { should == 'aaaa' }
+    end
+
+    context 'get from file' do
+      before { subject.body = nil }
+      before { File.write(subject.filename, 'aaaa') }
+      its(:body) { should == 'aaaa' }
+    end
+  end
+  
+  context '#save_with_file' do
+    context 'save if body exists' do
+      before { subject.body = 'aaaa' }
+      before { subject.save }
+      it { expect(File.read(subject.filename)).to eql('aaaa') }
+    end
+
+    context 'does not save if body does not exist' do
+      before { subject.body = nil }
+      before { subject.save }
+      it { expect(File.exist?(subject.filename)).to be_false }
+    end
+  end
+
+  context '#destroy_with_file' do
+    context 'delete if file exists' do
+      before { subject.save }
+      before { subject.destroy }
+      it { expect(File.exist?(subject.filename)).to be_false }
+    end
+
+    context 'fine even if file does not exist' do
+      before { subject.destroy }
+      it { expect(File.exist?(subject.filename)).to be_false }
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'rubygems'
 require 'rspec'
 $LOAD_PATH.unshift(File.dirname(__FILE__) + '/../lib')
 require 'fluentd_server'
+require 'pry'
 
 require 'fluentd_server/environments'
 require 'rake'


### PR DESCRIPTION
To save and load fluentd config contents on local files rather than db. 
This would be useful when users want to manage fluentd config files with git. 
